### PR TITLE
Update README to show most recent Python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Use a local development server that regenerates the output whenever the input ch
 
 ```
 git clone git@github.com:ghostbsd/documentation.git
-sudo pkg install -y py38-pip py38-sphinx py38-myst-parser py38-sphinx_rtd_theme gmake
+sudo pkg install -y py39-pip py39-sphinx py39-myst-parser py39-sphinx_rtd_theme gmake
 pip install docutils==0.16
 sudo pip install sphinx-autobuild
 cd documentation


### PR DESCRIPTION
If the user copies the commands from the README they will get an error since ports uses py39, not py38.

I also propose changing the install commands. We can simplify by:
1. Installing all python packages from FreeBSD ports.
2. Installing only **py39-pipenv**, and putting a pipfile (package list) in the repo.

Option 2 has the benefits of separating system and development packages and more controlled versioning of the development packages. 

I can make any changes in this PR or a new one.

