### PR TITLE
Fixing a typo in getting-started.md

### DIFF
--- a/source/user/installation-guide/getting-started.md
+++ b/source/user/installation-guide/getting-started.md
@@ -64,7 +64,7 @@ dd if=/path/to/GhostBSD-YY.MM.DD.iso of=/dev/diskX bs=3m
 ```
 
 **On Windows**
-* Download and run the imaging tool, Rufus, from the [webiste](https://rufus.ie/en/).
+* Download and run the imaging tool, Rufus, from the [website](https://rufus.ie/en/).
 * Insert the USB flash drive.
 * Make sure the flash drive is shown in Rufus under **Device**.
 * Click "SELECT" and choose the GhostBSD ISO file.


### PR DESCRIPTION
The make a bootable USB device on Windows section had a small typo, "webiste" instead of "website".