### PR TITLE
Update dev tool  installation in FAQ.md

### DIFF
--- a/source/user/FAQ.md
+++ b/source/user/FAQ.md
@@ -84,8 +84,8 @@ To upgrade GhostBSD, use the Update Station. It was made to upgrade GhostBSD pro
 
 ### Why can't I compile code or ports on GhostBSD?
 
-GhostBSD does not come with **os-generic-userland-devtools** preinstall anymore. To enable the capability to compile code and ports install **os-generic-userland-devtools**.
+GhostBSD no longer comes with dev tools preinstalled. To enable the capability to compile code and ports, install all GhostBSD*dev packages using the following command.
 
 ```
-sudo pkg install os-generic-userland-devtools
+sudo pkg install -g 'GhostBSD*-dev'
 ```

--- a/source/user/FAQ.md
+++ b/source/user/FAQ.md
@@ -84,7 +84,9 @@ To upgrade GhostBSD, use the Update Station. It was made to upgrade GhostBSD pro
 
 ### Why can't I compile code or ports on GhostBSD?
 
-GhostBSD no longer comes with dev tools preinstalled. To enable the capability to compile code and ports, install all GhostBSD*dev packages using the following command.
+GhostBSD no longer comes with development tools preinstalled. To enable the capability to compile code and ports, install the GhostBSD*-dev packages. These packages include essential build tools, compilers, and libraries necessary for software development. Use the following command to install them:
+
+pkg install ghostbsd-devel
 
 ```
 sudo pkg install -g 'GhostBSD*-dev'


### PR DESCRIPTION
This is related to https://github.com/ghostbsd/issues/issues/167

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the FAQ documentation to provide new instructions for installing development tools on GhostBSD, replacing the old package with a new command to install all relevant development packages.

Documentation:
- Update the FAQ to reflect changes in the installation process for development tools on GhostBSD, advising users to install all GhostBSD*dev packages instead of os-generic-userland-devtools.

<!-- Generated by sourcery-ai[bot]: end summary -->