### PR TITLE
Fixed command line in upgrading-guide.md

### DIFF
--- a/source/user/upgrading-guide.md
+++ b/source/user/upgrading-guide.md
@@ -87,11 +87,11 @@ If a similar message than the above one is encounter, **sudo pkg upgrade -f** mu
 ### Starting the upgrade
 Run the command below if there is a kernel mismatch with **update -f**.
 ```
-sudo pkg update -f
+sudo pkg upgrade -f
 ```
 Run the command below if there no kernel mismatch with **update -f**.
 ```
-sudo pkg update
+sudo pkg upgrade
 ```
 
 ### After the upgrade


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the command line instructions in the upgrading guide to ensure the correct use of 'sudo pkg upgrade' for upgrading processes.

Documentation:
- Correct the command line instructions in the upgrading guide to use 'sudo pkg upgrade' instead of 'sudo pkg update'.

<!-- Generated by sourcery-ai[bot]: end summary -->