### PR TITLE
Troubleshooting: expand and update

### DIFF
--- a/source/user/installation-guide/troubleshooting.md
+++ b/source/user/installation-guide/troubleshooting.md
@@ -46,7 +46,6 @@ Users of affected Apple hardware may find it impossible to set the Mac to use a 
 ### The installation ISO may be outdated.
 
 Try creating a bootable USB using the [latest image](https://www.ghostbsd.org/download).
-GhostBSD is a rolling release and ocassionally updates and fixes are pushed to the latest build before a new official image is created.
 
 ### …
 

--- a/source/user/installation-guide/troubleshooting.md
+++ b/source/user/installation-guide/troubleshooting.md
@@ -43,9 +43,6 @@ If your computer BIOS allows one of two GPUs to be disabled: please make this se
 
 Users of affected Apple hardware may find it impossible to set the Mac to use a single GPU.
 
-### The installation ISO may be outdated.
-
-Try creating a bootable USB using the [latest image](https://www.ghostbsd.org/download).
 
 ### …
 

--- a/source/user/installation-guide/troubleshooting.md
+++ b/source/user/installation-guide/troubleshooting.md
@@ -12,11 +12,13 @@ Support for Secure Boot is [not yet integral to FreeBSD](https://wiki.freebsd.or
 GhostBSD is based on [the STABLE branch](https://www.freebsd.org/where/#helptest) of FreeBSD.
 Hardware support is generally good, however, there may be issues with some modern hardware.
 
-To determine whether the issue relates to your hardware, or to the bootable USB:
+To determine whether the issue relates to hardware, or to the USB drive:
 
-- try to boot the live system on a different computer.
+- try to boot from the same drive on a different computer.
 
-Please refer to [FreeBSD Hardware Compatibility](https://docs.freebsd.org/en/books/faq/#hardware) for more information on indiviual components.
+For information about hardware components, please see FreeBSD information for the _RELEASE_ that corresponds to the version of _STABLE_ used by GhostBSD.
+
+You can run `ghostbsd-version -kv` to show the version number. As an example, _**14**0**1**502_ was from the _14.1-STABLE_ branch, and **hardware information** is amongst the pages at <https://www.freebsd.org/releases/14.1R/>.
 
 ### The installation media may be corrupted.
 

--- a/source/user/installation-guide/troubleshooting.md
+++ b/source/user/installation-guide/troubleshooting.md
@@ -27,14 +27,14 @@ Please refer to the [Getting started](getting-started.md) guide to download a ne
 
 ## The live system does not reach a graphical desktop environment.
 
-### GhostBSD automated configuration of X.Org does not support some dual-GPU configurations.
+### GhostBSD automated configuration does not support some dual-GPU configurations.
 
 Symptoms may include:
 
 - _Setting up (Intel DRM).. Please wait.._ -- on screen, no progress beyond this line
 - a mostly black screen -- a white rectangle in the upper left corner, with a pointer that can not be moved.
 
-Auto-config may fail with, for example: 
+Auto-config (kernel modules, other graphics drivers, X.Org) may fail with, for example: 
 
 - computers that support [NVIDIA Optimus](https://en.wikipedia.org/wiki/Nvidia_Optimus)
 - some dual-GPU Macs.

--- a/source/user/installation-guide/troubleshooting.md
+++ b/source/user/installation-guide/troubleshooting.md
@@ -3,20 +3,35 @@ Troubleshooting
 
 ## The live system does not boot.
 
+### If Secure Boot is enabled, in BIOS settings for your computer, disable it.
+
+Support for Secure Boot is [not yet integral to FreeBSD](https://wiki.freebsd.org/SecureBoot).
+
 ### Your hardware may not be supported.
 
-GhostBSD is based on the FreeBSD Stable branch and hardware support can change often. Hardware support is generally good, however, some more recent hardware may have issues. You can try to boot the live system on another computer to determine if the issue is related to your hardware or with the bootable USB itself.
+GhostBSD is based on [the STABLE branch](https://www.freebsd.org/where/#helptest) of FreeBSD.
+Hardware support is generally good, however, there may be issues with some modern hardware.
+
+To determine whether the issue relates to your hardware, or to the bootable USB:
+
+- try to boot the live system on a different computer.
 
 Please refer to [FreeBSD Hardware Compatibility](https://docs.freebsd.org/en/books/faq/#hardware) for more information on indiviual components.
 
 ### The installation media may be corrupted.
 
-Ocassionally, ISO files may become corrupted during download or during the creation of a bootable USB flash drive. Please refer to the [Getting started](getting-started.md) guide to download a new ISO file and create a new bootable USB flash drive.
+Corruption may occur during download of an installer image file, or during creation of a bootable USB flash drive.
+Please refer to the [Getting started](getting-started.md) guide to download a new image and create a new bootable USB flash drive.
 
 ## The live system does not reach a graphical desktop environment.
 
-### The installation ISO may be outdated or require general bug fixes.
+…
 
-Try creating a bootable USB using the [latest iso](https://www.ghostbsd.org/download) found on the Download page under *Latest Builds*. GhostBSD is a rolling release and ocassionally updates and fixes are pushed to the latest build before a new official image is created.
+### The installation ISO may be outdated.
 
-*Please note*: This section is incomplete and is currently being updated.
+Try creating a bootable USB using the [latest image](https://www.ghostbsd.org/download).
+GhostBSD is a rolling release and ocassionally updates and fixes are pushed to the latest build before a new official image is created.
+
+----
+
+Please note: this page is incomplete.

--- a/source/user/installation-guide/troubleshooting.md
+++ b/source/user/installation-guide/troubleshooting.md
@@ -27,13 +27,27 @@ Please refer to the [Getting started](getting-started.md) guide to download a ne
 
 ## The live system does not reach a graphical desktop environment.
 
-…
+### GhostBSD automated configuration of X.Org does not support some dual-GPU configurations.
+
+Symptoms may include:
+
+- _Setting up (Intel DRM).. Please wait.._ -- on screen, no progress beyond this line
+- a mostly black screen -- a white rectangle in the upper left corner, with a pointer that can not be moved.
+
+Auto-config may fail with, for example: 
+
+- computers that support [NVIDIA Optimus](https://en.wikipedia.org/wiki/Nvidia_Optimus)
+- some dual-GPU Macs.
+
+If your computer BIOS allows one of two GPUs to be disabled: please make this setting before your next attempt to boot the live system.
+
+Users of affected Apple hardware may find it impossible to set the Mac to use a single GPU.
 
 ### The installation ISO may be outdated.
 
 Try creating a bootable USB using the [latest image](https://www.ghostbsd.org/download).
 GhostBSD is a rolling release and ocassionally updates and fixes are pushed to the latest build before a new official image is created.
 
-----
+### …
 
-Please note: this page is incomplete.
+Please note: this section is incomplete.


### PR DESCRIPTION
Add a section for Secure Boot.

Link to STABLE.

For hardware components, direct readers to hardware information that is provided by the FreeBSD Primary Release Engineering Team.

Add two dual-GPU scenarios.

Add a placeholder (ellipsis) subheading for the section that is incomplete.

Whilst here, reword things a little.

## Original (draft) Summary by Sourcery

Expand and update the troubleshooting guide by adding Secure Boot information, updating links, and rewording sections for clarity.

Documentation:
- Add information about disabling Secure Boot in BIOS settings for troubleshooting boot issues.
- Update the link to the FreeBSD STABLE branch for hardware support information.
- Include a placeholder for missing desktop environment issues in the troubleshooting guide.
- Reword and clarify sections on hardware support and installation media corruption.