### PR TITLE
Update ports documentation to reflect renaming of FreeBSD `master` to main

### DIFF
--- a/contributor/ports/maintaining-ports-tree.md
+++ b/contributor/ports/maintaining-ports-tree.md
@@ -56,16 +56,13 @@ Fetch the latest changes from FreeBSD:
 ```shell
 git fetch freebsd
 ```
-Merge FreeBSD’s `master` branch into your branch:
+Merge FreeBSD’s `main` branch into your branch:
 ```shell
-git merge freebsd/master
+git merge freebsd/main
 ```
 
 - **If no conflicts occur**: Proceed to Step 5 (Testing).
 - **If conflicts occur**: Continue to Step 4 (Resolving Conflicts).
-
-You’re right—my wording for directory conflicts suggests restoring GhostBSD’s version when FreeBSD renames or removes a directory, but you want the resolver to ensure files are moved and the old directory is removed, aligning with FreeBSD’s change. Here’s the corrected section:
-
 ---
 
 ### 4. Resolve Merge Conflicts


### PR DESCRIPTION
- Updated instructions for merging FreeBSD’s repository to use `main` branch instead of `master`.
- Removed unnecessary explanatory text for resolving directory conflicts.

## Summary by Sourcery

Update ports documentation to use FreeBSD’s main branch instead of master and remove outdated conflict resolution text

Documentation:
- Replace references to FreeBSD’s master branch with main in the ports tree instructions
- Remove unnecessary explanatory section on resolving directory conflicts