### PR TITLE
Fix typo in installation-guide.md

### DIFF
--- a/user/installation-guide/installation-guide.md
+++ b/user/installation-guide/installation-guide.md
@@ -11,7 +11,7 @@ After reading this guide, you will know:
 * How to set up a Virtual Machine. 
 * How to install GhostBSD.
   * How to install GhostBSD using the entire disk drive. 
-  * How to install alongside other opereating system.
+  * How to install alongside other operating system(s).
 * Troubleshooting the installer and live media.
 
 ```{toctree}


### PR DESCRIPTION
## Summary by Sourcery

Fix a typo in the installation guide to improve clarity

Documentation:
- Correct the misspelling of “opereating” to “operating” in installation-guide.md
- Adjust phrasing to pluralize “operating system(s)” for accuracy